### PR TITLE
Add pytest tests for RAG modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,14 @@ O projeto está organizado nos seguintes diretórios-chave:
 Para começar com este projeto, clone o repositório e explore os notebooks e scripts. Você precisará ter um ambiente Python configurado com as dependências necessárias (listadas em `requirements.txt`, se fornecido). Abra os notebooks no Jupyter e acompanhe os exemplos de código.
 
 Aproveite a exploração do fascinante mundo de NLP e ML com TSI-LLM!
+
+## Running Tests
+
+The repository now includes simple unit tests for the RAG modules. After
+installing the required dependencies, run them with:
+
+```bash
+pytest
+```
+
+The tests exercise the ingestion, retrieval and answer generation functions.

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_community")
+pytest.importorskip("langchain_ollama")
+
+from rag.ingestion import ingest_data, clear_db
+from rag.retrieval import load_db, get_relevant_docs
+from rag.generation import generate_answer
+
+PDF1 = "data/PPC_TSI_EaD.pdf"
+INDEX = "faiss_index"
+
+
+def test_ingest_create_or_load():
+    clear_db(INDEX)
+    db = ingest_data(pdf_path=PDF1, index_path=INDEX, update_existing_db=True)
+    assert os.path.exists(INDEX)
+    assert db.index.ntotal > 0
+    db2 = ingest_data(pdf_path=PDF1, index_path=INDEX, update_existing_db=False)
+    assert db2.index.ntotal == db.index.ntotal
+
+
+def test_get_relevant_docs_returns_docs():
+    db = load_db(index_path=INDEX)
+    docs = get_relevant_docs(db, query="Quais são as disciplinas do curso?", k=5)
+    assert len(docs) > 0
+
+
+def test_generate_answer_not_empty():
+    db = load_db(index_path=INDEX)
+    docs = get_relevant_docs(db, query="Quais são as disciplinas do curso?", k=5)
+    answer = generate_answer(docs, "Quais são as disciplinas do curso?")
+    assert isinstance(answer, str)
+    assert answer.strip() != ""


### PR DESCRIPTION
## Summary
- add a test suite exercising the RAG ingestion, retrieval and generation functions
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684629ea8e14832c9d498059c81abb57